### PR TITLE
make static build work

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,6 @@
             ${oldAttrs.postFixup or ""}
             cat <<EOF >> $dev/lib/pkgconfig/libcryptsetup.pc
               Requires.private: uuid, json-c, devmapper, libcrypto, blkid
-              Libs.private: -lc
             EOF
           '';
         });
@@ -76,6 +75,8 @@
           # ref: https://doc.rust-lang.org/cargo/reference/config.html#targettriplelinker
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = with pkgs.pkgsStatic.stdenv;
             "${cc}/bin/${cc.targetPrefix}gcc";
+          # link against libc.a
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = "-lc";
 
           doCheck = true;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,15 @@
           cargo = toolchain;
           rustc = toolchain;
         };
+        cryptsetup-with-deps = pkgs.pkgsStatic.cryptsetup.overrideAttrs (_: oldAttrs: {
+          postFixup = ''
+            ${oldAttrs.postFixup or ""}
+            cat <<EOF >> $dev/lib/pkgconfig/libcryptsetup.pc
+              Requires.private: uuid, json-c, devmapper, libcrypto, blkid
+              Libs.private: -lc
+            EOF
+          '';
+        });
       in
       rec {
         defaultPackage = packages.x86_64-unknown-linux-musl;
@@ -42,7 +51,7 @@
           src = ./.;
 
           nativeBuildInputs = with pkgs; [ pkgsStatic.stdenv.cc pkgsStatic.pkg-config ];
-          buildInputs = with pkgs; [ pkgsStatic.cryptsetup rustPlatform.bindgenHook ];
+          buildInputs = with pkgs; [ cryptsetup-with-deps rustPlatform.bindgenHook ];
 
           # Configures the target which will be built.
           # ref: https://doc.rust-lang.org/cargo/reference/config.html#buildtarget
@@ -65,8 +74,8 @@
           # This is only necessary if rustc doesn't already know the correct linker to use.
           #
           # ref: https://doc.rust-lang.org/cargo/reference/config.html#targettriplelinker
-          # CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = with pkgs.pkgsStatic.stdenv;
-          #   "${cc}/bin/${cc.targetPrefix}gcc";
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = with pkgs.pkgsStatic.stdenv;
+            "${cc}/bin/${cc.targetPrefix}gcc";
 
           doCheck = true;
         };


### PR DESCRIPTION
> ./result/bin/staticcryptsetup: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, not stripped

There appear to be two issues that prevented a static build from just working:
1. `cryptsetup` does not declare its private dependencies in its pkg-config, so `cryptsetup-rs-sys` does not emit all the required link flags for a static build.
2. naersk uses `pkgs.stdenv` as its builder, this causes issues where it either does not find the MUSL `libc` implemention or links against gcc's libc. It might work if you can override naersk to use `pkgsStatic.stdenv` but for now explicitly specifying the linker and telling it to link to libc appears to work.